### PR TITLE
Fix broken link to Tuning.java

### DIFF
--- a/content/docs/pathing/migrating.mdx
+++ b/content/docs/pathing/migrating.mdx
@@ -25,7 +25,7 @@ converter into that class.
 </Callout>
 
 ## Add the tuning OpModes
-Copy the [`Tuning.java` file](https://github.com/Pedro-Pathing/Quickstart/blob/dev/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java)
+Copy the [`Tuning.java` file](https://github.com/Pedro-Pathing/Quickstart/blob/master/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java)
 and place it in your project.
 
 This OpMode contains all the tuners and tests needed to tune Pedro and verify


### PR DESCRIPTION
The link to Tuning.java on https://pedropathing.com/docs/pathing/migrating was broken, presumably because the dev branch has been deleted.

Thanks for the great work on Pedro Pathing. We're looking forward to using 2.0!

Julien, Coach #21615 Rocket Robotics.