### PR TITLE
Fix typo in offsets tuner documentation

### DIFF
--- a/content/docs/pathing/tuning/localization/offsets-tuner.mdx
+++ b/content/docs/pathing/tuning/localization/offsets-tuner.mdx
@@ -6,7 +6,7 @@ title: Offsets Tuner
 This tuner is made to automatically find odometry offsets for [Two Wheel](https://pedropathing.com/docs/pathing/tuning/localization/two-wheel) and [Pinpoint](https://pedropathing.com/docs/pathing/tuning/localization/pinpoint) localizers.  
 Currently, it only supports two deadwheels in the calculations.  
 Before using this tuner, you **must** set both of your odometry offsets to both be 0.
-The tuner is apart of the Tuning.java in 2.1.0 or later versions; however, it can be copied over to previous versions [here](https://github.com/Pedro-Pathing/Quickstart/blob/master/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java#L1222).
+The tuner is a part of the Tuning.java in 2.1.0 or later versions; however, it can be copied over to previous versions [here](https://github.com/Pedro-Pathing/Quickstart/blob/master/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java#L1222).
 ### Steps
 * Set both localizer offsets (forwardPodY and strafePodX) to be 0.
 * Place the robot in the corner of the field or corner of a tile facing a cardinal direction.


### PR DESCRIPTION
Previously said apart instead of a part.