### PR TITLE
Redesign hompage

### DIFF
--- a/app/(home)/Item.tsx
+++ b/app/(home)/Item.tsx
@@ -2,10 +2,11 @@ import type { ReactNode } from "react";
 import { ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 
-export default function Item({ title, icon, iconClassName, description, href, link = false }: {
+export default function Item({ title, icon, iconClassName, accentClassName, description, href, link = false }: {
   title: string,
   icon: ReactNode,
   iconClassName: string,
+  accentClassName?: string,
   description: string,
   href: string,
   link?: boolean,
@@ -13,19 +14,21 @@ export default function Item({ title, icon, iconClassName, description, href, li
   const Component = link ? Link : "a";
 
   return (
-    <Component href={href}
-      className="group my-8 xl:my-0 block xl:basis-0 xl:grow min-w-0 p-6 opacity-75 bg-neutral-300/50 dark:bg-neutral-950/50 border-mauve-400/25 border shadow-sm rounded-4xl transition-all duration-300 hover:-translate-y-1 hover:shadow-lg hover:bg-neutral-400/60 dark:hover:bg-neutral-950/80 hover:opacity-100">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <div className={`rounded-xl size-12 p-2 border-2 ${iconClassName}`}>
+    <Component
+      href={href}
+      className="group my-6 xl:my-0 block xl:basis-0 xl:grow min-w-0 p-6 bg-neutral-300/40 dark:bg-neutral-950/40 border-mauve-400/25 border shadow-sm rounded-4xl backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:bg-neutral-400/60 dark:hover:bg-neutral-950/80"
+    >
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-4 min-w-0">
+          <div className={`shrink-0 rounded-xl size-12 p-2 border-2 ${iconClassName}`}>
             {icon}
           </div>
-          <span className="text-black dark:text-white/75 text-xl">{title}</span>
+          <span className="text-black dark:text-white/90 text-xl">{title}</span>
         </div>
         <ArrowUpRight
-          className="text-black dark:text-white size-10 border-sky-500 border-2 rounded-full p-1 opacity-60 group-hover:opacity-100 transition-opacity duration-300" />
+          className={`shrink-0 text-black dark:text-white size-10 border-2 rounded-full p-1 opacity-60 group-hover:opacity-100 group-hover:rotate-12 transition-all duration-300 ${accentClassName ?? "border-sky-500"}`} />
       </div>
-      <p className="text-black/60 dark:text-white/50 mt-4 xl:overflow-hidden xl:text-nowrap">{description}</p>
+      <p className="text-black/60 dark:text-white/55 mt-4">{description}</p>
     </Component>
-  )
+  );
 }

--- a/app/(home)/PedroSelector.tsx
+++ b/app/(home)/PedroSelector.tsx
@@ -1,19 +1,20 @@
 'use client';
-import {useEffect, useMemo, useState} from "react";
-import Particles, {initParticlesEngine} from "@tsparticles/react";
-import {loadSlim} from "@tsparticles/slim";
+import { useEffect, useMemo, useState } from "react";
+import Particles, { initParticlesEngine } from "@tsparticles/react";
+import { loadSlim } from "@tsparticles/slim";
 import particlesOptions from "@/app/(home)/particlesOptions";
 import Row from "@/app/(home)/Row";
 import Item from "@/app/(home)/Item";
-import {Book, Leaf, Moon, Package, SplinePointer, Sun} from "lucide-react";
-import {SiDiscord, SiGithub, SiInstagram, SiYoutube} from "@icons-pack/react-simple-icons";
-import {Footer} from "@/app/Footer";
-import {useTheme} from "next-themes";
+import { ArrowRight, Book, Leaf, Moon, Package, SplinePointer, Sun } from "lucide-react";
+import { SiDiscord, SiGithub, SiInstagram, SiYoutube } from "@icons-pack/react-simple-icons";
+import { Footer } from "@/app/Footer";
+import { useTheme } from "next-themes";
+import Link from "next/link";
 
 export default function PedroSelector() {
     const [init, setInit] = useState(false);
     const [mounted, setMounted] = useState(false);
-    const {resolvedTheme, setTheme} = useTheme();
+    const { resolvedTheme, setTheme } = useTheme();
     useEffect(() => {
         setMounted(true);
         initParticlesEngine(loadSlim).then(() => setInit(true));
@@ -25,10 +26,10 @@ export default function PedroSelector() {
             ...particlesOptions,
             particles: {
                 ...particlesOptions.particles,
-                color: {value: color},
+                color: { value: color },
                 links: {
                     ...particlesOptions.particles.links,
-                    color: {value: color},
+                    color: { value: color },
                 },
             },
         };
@@ -38,74 +39,132 @@ export default function PedroSelector() {
         <>
             <button
                 onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+                aria-label="Toggle theme"
                 className="fixed top-4 left-4 z-50 p-2 rounded-full bg-neutral-300/50 dark:bg-neutral-950/50 border border-mauve-400/25 text-black dark:text-white opacity-60 hover:opacity-100 transition-opacity duration-300"
             >
-                {mounted && (resolvedTheme === 'dark' ? <Sun className="size-5"/> : <Moon className="size-5"/>)}
+                {mounted && (resolvedTheme === 'dark' ? <Sun className="size-5" /> : <Moon className="size-5" />)}
             </button>
-            {init && <Particles className="hidden xl:block" options={options}/>}
+            {init && <Particles className="hidden xl:block" options={options} />}
 
-            <div
-                className="mx-auto mt-16 xl:mb-4 p-6 opacity-75 bg-neutral-300/50 dark:bg-neutral-950/25 border-mauve-400/25 border shadow-sm relative rounded-4xl max-w-xs transition-all duration-300 hover:shadow-lg hover:bg-neutral-400/60 dark:hover:bg-neutral-950/80 hover:opacity-100">
-                <img src="/logo-stacked-dark.svg" alt="Pedro Logo" draggable="false" className="dark:hidden"/>
-                <img src="/logo-stacked-light.svg" alt="Pedro Logo" draggable="false" className="hidden dark:block"/>
-            </div>
+            <section className="relative px-6 pt-20 pb-8 text-center animate-fade-up">
+                <div className="mx-auto mb-8 p-5 bg-neutral-300/40 dark:bg-neutral-950/40 border-mauve-400/25 border shadow-sm rounded-3xl backdrop-blur-sm max-w-[14rem] transition-all duration-300 hover:shadow-lg hover:bg-neutral-400/60 dark:hover:bg-neutral-950/80">
+                    <img src="/logo-stacked-dark.svg" alt="Pedro Pathing" draggable="false" className="dark:hidden" />
+                    <img src="/logo-stacked-light.svg" alt="Pedro Pathing" draggable="false" className="hidden dark:block" />
+                </div>
 
-            <main className="p-8">
-                <Row>
-                    <Item link href="/docs"
-                          title="Pedro Pathing"
-                          iconClassName="border-yellow-500/65 bg-neutral-400 dark:bg-neutral-800"
-                          description="The most popular autonomous pathing library for FTC"
-                          icon={<img src="/logo-duck.svg" alt="Pedro Pathing Logo" className="w-full"/>}/>
-                    <Item link href="/docs/ivy"
-                          title="Ivy"
-                          iconClassName="border-green-500/65 bg-green-500/10"
-                          description="A minimal command-based control flow framework"
-                          icon={<Leaf className="text-green-500 size-full"/>}/>
-                    <Item href="https://visualizer.pedropathing.com"
-                          title="Visualizer"
-                          iconClassName="border-purple-600/65 bg-purple-600/10"
-                          description="An interactive, web-based autonomous path generator"
-                          icon={<SplinePointer className="text-purple-600 size-full"/>}/>
-                </Row>
-                <Row>
-                    <Item href="https://github.com/Pedro-Pathing"
-                          title="GitHub"
-                          iconClassName="border-gray-500/65 bg-gray-500/10"
-                          description="View our source code on GitHub"
-                          icon={<SiGithub className="text-gray-500 size-full"/>}/>
-                    <Item href="https://discord.gg/bqRdAjEmjk"
-                          title="Discord"
-                          iconClassName="border-blue-500/65 bg-blue-500/10"
-                          description="Chat with us on Discord"
-                          icon={<SiDiscord className="text-blue-500 size-full"/>}/>
-                    <Item href="https://youtube.com/@PedroPathing"
-                          title="YouTube"
-                          iconClassName="border-red-500/65 bg-red-500/10"
-                          description="Watch our videos on YouTube"
-                          icon={<SiYoutube className="text-red-500 size-full"/>}/>
-                </Row>
-                <Row>
-                    <Item href="https://instagram.com/pedropathing/"
-                          title="Instagram"
-                          iconClassName="border-pink-500/65 bg-pink-500/10"
-                          description="Follow us on Instagram"
-                          icon={<SiInstagram className="text-pink-500 size-full"/>}/>
-                    <Item href="https://central.sonatype.com/namespace/com.pedropathing"
-                          title="Packages"
-                          iconClassName="border-orange-500/65 bg-orange-500/10"
-                          description="View our packages on Maven Central"
-                          icon={<Package className="text-orange-500 size-full"/>}/>
-                    <Item href="https://javadoc.io/doc/com.pedropathing"
-                          title="Javadoc"
-                          iconClassName="border-pink-600/65 bg-pink-600/10"
-                          description="View our Javadoc"
-                          icon={<Book className="text-pink-600 size-full"/>}/>
-                </Row>
+                <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight mb-4">
+                    <span className="gradient-text">Drive smarter.</span>
+                    <br />
+                    <span className="text-black dark:text-white">Path further.</span>
+                </h1>
+                <p className="max-w-xl mx-auto text-base sm:text-lg text-black/65 dark:text-white/65 mb-8">
+                    The most popular autonomous pathing library for FIRST Tech Challenge — built for speed,
+                    precision, and the realities of competition robotics.
+                </p>
+                <div className="flex flex-wrap items-center justify-center gap-3">
+                    <Link
+                        href="/docs"
+                        className="group inline-flex items-center gap-2 px-6 py-3 rounded-full bg-[#FE55A2] hover:bg-[#ff6cae] text-white font-semibold shadow-lg shadow-pink-500/20 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-xl hover:shadow-pink-500/30"
+                    >
+                        Get started
+                        <ArrowRight className="size-4 transition-transform duration-300 group-hover:translate-x-0.5" />
+                    </Link>
+                    <a
+                        href="https://github.com/Pedro-Pathing"
+                        className="group inline-flex items-center gap-2 px-6 py-3 rounded-full bg-neutral-300/40 dark:bg-neutral-950/40 border border-mauve-400/25 text-black dark:text-white font-medium backdrop-blur-sm transition-all duration-300 hover:-translate-y-0.5 hover:bg-neutral-400/60 dark:hover:bg-neutral-950/80"
+                    >
+                        <SiGithub className="size-4" />
+                        Star on GitHub
+                    </a>
+                </div>
+            </section>
+
+            <main className="px-4 sm:px-8 pb-12 animate-fade-up" style={{ animationDelay: "0.15s" }}>
+                <div className="max-w-7xl mx-auto">
+                    <div className="flex items-center gap-3 px-2 xl:px-8 mb-2 xl:mb-0 mt-8 xl:mt-4">
+                        <h2 className="text-xs font-semibold uppercase tracking-widest text-black/50 dark:text-white/50">
+                            Products
+                        </h2>
+                        <div className="flex-1 h-px bg-gradient-to-r from-mauve-400/30 to-transparent" />
+                    </div>
+                    <Row>
+                        <Item link href="/docs"
+                            title="Pedro Pathing"
+                            iconClassName="border-yellow-500/65 bg-neutral-400 dark:bg-neutral-800"
+                            accentClassName="border-yellow-500"
+                            description="The most popular autonomous pathing library for FTC"
+                            icon={<img src="/logo-duck.svg" alt="" className="w-full" />} />
+                        <Item link href="/docs/ivy"
+                            title="Ivy"
+                            iconClassName="border-green-500/65 bg-green-500/10"
+                            accentClassName="border-green-500"
+                            description="A minimal command-based control flow framework"
+                            icon={<Leaf className="text-green-500 size-full" />} />
+                        <Item href="https://visualizer.pedropathing.com"
+                            title="Visualizer"
+                            iconClassName="border-purple-600/65 bg-purple-600/10"
+                            accentClassName="border-purple-600"
+                            description="An interactive, web-based autonomous path generator"
+                            icon={<SplinePointer className="text-purple-600 size-full" />} />
+                    </Row>
+
+                    <div className="flex items-center gap-3 px-2 xl:px-8 mb-2 xl:mb-0 mt-12 xl:mt-8">
+                        <h2 className="text-xs font-semibold uppercase tracking-widest text-black/50 dark:text-white/50">
+                            Resources
+                        </h2>
+                        <div className="flex-1 h-px bg-gradient-to-r from-mauve-400/30 to-transparent" />
+                    </div>
+                    <Row>
+                        <Item href="https://central.sonatype.com/namespace/com.pedropathing"
+                            title="Packages"
+                            iconClassName="border-orange-500/65 bg-orange-500/10"
+                            accentClassName="border-orange-500"
+                            description="View our packages on Maven Central"
+                            icon={<Package className="text-orange-500 size-full" />} />
+                        <Item href="https://javadoc.io/doc/com.pedropathing"
+                            title="Javadoc"
+                            iconClassName="border-pink-600/65 bg-pink-600/10"
+                            accentClassName="border-pink-600"
+                            description="Reference API documentation"
+                            icon={<Book className="text-pink-600 size-full" />} />
+                        <Item href="https://github.com/Pedro-Pathing"
+                            title="GitHub"
+                            iconClassName="border-gray-500/65 bg-gray-500/10"
+                            accentClassName="border-gray-500"
+                            description="View our source code on GitHub"
+                            icon={<SiGithub className="text-gray-500 dark:text-gray-300 size-full" />} />
+                    </Row>
+
+                    <div className="flex items-center gap-3 px-2 xl:px-8 mb-2 xl:mb-0 mt-12 xl:mt-8">
+                        <h2 className="text-xs font-semibold uppercase tracking-widest text-black/50 dark:text-white/50">
+                            Community
+                        </h2>
+                        <div className="flex-1 h-px bg-gradient-to-r from-mauve-400/30 to-transparent" />
+                    </div>
+                    <Row>
+                        <Item href="https://discord.gg/bqRdAjEmjk"
+                            title="Discord"
+                            iconClassName="border-blue-500/65 bg-blue-500/10"
+                            accentClassName="border-blue-500"
+                            description="Chat with us on Discord"
+                            icon={<SiDiscord className="text-blue-500 size-full" />} />
+                        <Item href="https://youtube.com/@PedroPathing"
+                            title="YouTube"
+                            iconClassName="border-red-500/65 bg-red-500/10"
+                            accentClassName="border-red-500"
+                            description="Watch our videos on YouTube"
+                            icon={<SiYoutube className="text-red-500 size-full" />} />
+                        <Item href="https://instagram.com/pedropathing/"
+                            title="Instagram"
+                            iconClassName="border-pink-500/65 bg-pink-500/10"
+                            accentClassName="border-pink-500"
+                            description="Follow us on Instagram"
+                            icon={<SiInstagram className="text-pink-500 size-full" />} />
+                    </Row>
+                </div>
             </main>
 
-
-            <Footer/>
+            <Footer />
         </>
-    )
+    );
 }

--- a/app/(home)/Row.tsx
+++ b/app/(home)/Row.tsx
@@ -1,9 +1,9 @@
-import type {ReactNode} from "react";
+import type { ReactNode } from "react";
 
-export default function Row({children}: { children: ReactNode }) {
-    return (
-        <div className="xl:flex xl:m-8 xl:gap-8 xl:row">
-            {children}
-        </div>
-    )
+export default function Row({ children }: { children: ReactNode }) {
+  return (
+    <div className="xl:flex xl:m-8 xl:gap-8 xl:row">
+      {children}
+    </div>
+  );
 }

--- a/app/global.css
+++ b/app/global.css
@@ -2,6 +2,43 @@
 @import 'fumadocs-ui/css/black.css';
 @import 'fumadocs-ui/css/preset.css';
 
+html {
+    scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+}
+
+::-webkit-scrollbar {
+    width: 12px;
+    height: 12px;
+}
+
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    background: rgba(254, 85, 162, 0.25);
+    border-radius: 9999px;
+    border: 3px solid transparent;
+    background-clip: content-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: rgba(254, 85, 162, 0.55);
+    background-clip: content-box;
+    border: 3px solid transparent;
+}
+
+* {
+    scrollbar-color: rgba(254, 85, 162, 0.35) transparent;
+    scrollbar-width: thin;
+}
+
 @theme {
     --color-fd-primary: #FE55A2;
     --color-fd-primary-foreground: hsl(0, 0%, 98%);
@@ -31,4 +68,45 @@ body {
         radial-gradient(ellipse 40% 30% at 80% 50%, rgba(254, 85, 162, 0.03), transparent);
     background-repeat: no-repeat;
     background-attachment: fixed;
+}
+
+@keyframes fade-up {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.animate-fade-up {
+    animation: fade-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .animate-fade-up {
+        animation: none;
+    }
+}
+
+.gradient-text {
+    background: linear-gradient(135deg, #FE55A2 0%, #ff8fc4 50%, #FE55A2 100%);
+    background-size: 200% auto;
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    animation: shimmer 4s linear infinite;
+}
+
+@keyframes shimmer {
+    0% { background-position: 0% center; }
+    100% { background-position: 200% center; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .gradient-text {
+        animation: none;
+    }
 }


### PR DESCRIPTION
### Summary
- Redesigned the home page with a hero section (animated gradient headline, tagline, primary/secondary CTAs) above the link grid
- Restructured cards into three labeled sections — Products (Pedro Pathing / Ivy / Visualizer), Resources (Packages / Javadoc / GitHub), and Community (Discord / YouTube / Instagram) — with per-card arrow accent colors that match each card's theme
- Polished interaction details: backdrop-blur cards, hover lift + shadow + arrow rotation, staggered fade-up entrance, smooth scroll, themed pink scrollbar, and prefers-reduced-motion guards throughout

### Test plan
- Open / and confirm hero, three sections, and footer all render
 - Verify full card descriptions are visible at every breakpoint (no truncation on xl)
 - Hover each card — accent ring color should match its icon theme (yellow / green / purple / orange / pink-600 / gray / blue / red / pink-500)
 - Toggle the theme button (top-left) and confirm light + dark both look correct
 - Scroll the page and confirm smooth scroll + pink scrollbar
 - Click "Get started" → /docs, "Star on GitHub" → repo, and verify each card link target
 - Test at mobile width — cards stack vertically, hero remains readable
 - Enable OS "reduce motion" setting and confirm animations disable
 
 ### Screenshots
 ## Before
 
<img width="1929" height="946" alt="image" src="https://github.com/user-attachments/assets/e71384af-25ab-4e53-836d-e2af0270d848" />

## Now

<img width="1924" height="944" alt="image" src="https://github.com/user-attachments/assets/b6c6c0ed-06f8-4a5a-9a04-66fcebe6bddc" />
